### PR TITLE
caching constants along with bytecode

### DIFF
--- a/axonvm/script_cache.go
+++ b/axonvm/script_cache.go
@@ -452,6 +452,7 @@ func (p *cachedProgramBinaryPayload) Deserialize(reader io.Reader) error {
 			p.Program.OptionCompare,
 			p.Program.OptionExplicit,
 			p.Program.SourceName,
+			p.Program.Constants,
 		)
 	}
 
@@ -1065,6 +1066,7 @@ func (c *ScriptCache) loadDiskProgram(filePath string, sourceInfo os.FileInfo) (
 		payload.Program.OptionCompare,
 		payload.Program.OptionExplicit,
 		payload.Program.SourceName,
+		payload.Program.Constants,
 	)
 	return immutableCachedProgramView(payload.Program), true
 }

--- a/axonvm/script_cache_symbols.go
+++ b/axonvm/script_cache_symbols.go
@@ -79,9 +79,27 @@ func getBaseGlobalDictionary() *baseGlobalDictionary {
 	return &baseGlobalsData
 }
 
-func computeProgramHash(bytecode []byte, globalCount int, optionCompare int, optionExplicit bool, sourceName string) uint64 {
+func computeProgramHash(bytecode []byte, globalCount int, optionCompare int, optionExplicit bool, sourceName string, constants []Value) uint64 {
 	h := xxhash.New()
 	_, _ = h.Write(bytecode)
+
+	// hash constants
+	for _, c := range constants {
+		binary.Write(h, binary.LittleEndian, uint8(c.Type))
+		binary.Write(h, binary.LittleEndian, c.Num)
+		binary.Write(h, binary.LittleEndian, c.Flt)
+		switch c.Type {
+		case VTString, VTUserSub, VTJSFunctionTemplate, VTJSArrowFunctionTemplate, VTSymbol:
+			h.WriteString(c.Str)
+		}
+
+		if c.Type == VTUserSub || c.Type == VTJSFunctionTemplate || c.Type == VTJSArrowFunctionTemplate {
+			for _, name := range c.Names {
+				h.WriteString(name)
+			}
+		}
+	}
+
 	h.WriteString(strings.TrimSpace(sourceName))
 	var raw [8]byte
 	binary.LittleEndian.PutUint64(raw[:], uint64(globalCount))
@@ -188,6 +206,7 @@ func buildCachedProgramFromCompiler(compiler *Compiler) CachedProgram {
 		program.OptionCompare,
 		program.OptionExplicit,
 		program.SourceName,
+		program.Constants,
 	)
 	return program
 }

--- a/axonvm/vm_pool.go
+++ b/axonvm/vm_pool.go
@@ -205,6 +205,7 @@ func pooledProgramKey(program CachedProgram) string {
 			program.OptionCompare,
 			program.OptionExplicit,
 			program.SourceName,
+			program.Constants,
 		)
 	}
 	if sourceName != "" {


### PR DESCRIPTION
with bytecode_caching_enabled = "disabled" asp is served from cache if only constants was changed in asp file
example
open asp in browser
```vbscript
<% response.write "111" %>
```

change asp file to 
```vbscript
<% response.write "222" %>
```
refresh page
page will still be "111"

i've added hashing constants to computeProgramHash

