### PR TITLE
fix: Only clear output from global.asa, not the whole response

### DIFF
--- a/axonvm/global_asa.go
+++ b/axonvm/global_asa.go
@@ -155,7 +155,10 @@ func (g *GlobalASA) executeHandler(host ASPHostEnvironment, handlerIdx int, hand
 	defer vm.Release()
 
 	// Suppress standard response output for Global.asa handlers to match IIS behavior.
-	host.Response().Output = nil
+	response := host.Response()
+	originalOutput := response.Output
+	response.Output = nil
+	defer func() { response.Output = originalOutput }()
 
 	// Run the top-level code to populate Sub/Function declarations into global variables
 	// and the JScript environment.


### PR DESCRIPTION
On the first request in a new session, the global.asa handler would clear the entire response body, not just its own output.
To fix this, we preserve the original response and write it to the buffer later.

How to reproduce the original error:
start server with `build/linux-amd64/axonasp-http`
`curl localhost:8801` always returns empty response body.

What this PR fixes:
`curl localhost:8801` returns the expected HTTP response including its body.

It also keeps the original behavior intact that the buffer from global.asa is not written to the client.