### PR TITLE
Fix ReDim Preserve on 1-D jagged arrays failing with 800A0005

### DIFF
--- a/axonvm/builtins.go
+++ b/axonvm/builtins.go
@@ -1189,13 +1189,19 @@ func vbsAxonRedimPreserveArrayVB6(args []Value) (Value, error) {
 
 	// VB6 Rule: In ReDim Preserve, only the last dimension can be changed,
 	// and even for the last dimension, the lower bound cannot be changed.
-	existingBounds := vbArrayUpperBounds(source)
-	// We need lower bounds too for full check
+	//
+	// The array's dimensionality is taken from the number of subscripts the
+	// caller supplied (VBScript requires ReDim Preserve to match the array's
+	// declared rank), NOT by structurally probing element [0]. A 1-D "jagged"
+	// array whose first element is itself an array must be treated as 1-D, so
+	// probing Values[0] would wrongly classify it as multi-dimensional and
+	// reject a legitimate resize with 800A0005 (issue #32).
+	numDims := len(bounds) / 2
 	current := source
-	for i := range existingBounds {
+	for i := 0; i < numDims; i++ {
 		newLow := bounds[i*2]
 		newHigh := bounds[i*2+1]
-		if i < len(existingBounds)-1 {
+		if i < numDims-1 {
 			// Not the last dimension: must match exactly
 			if newLow != current.Lower || newHigh != current.Upper() {
 				return NewEmpty(), newBuiltinVBRuntimeError(vbscript.InvalidProcedureCallOrArgument, vbscript.InvalidProcedureCallOrArgument.String())

--- a/axonvm/vm_dim_redim_test.go
+++ b/axonvm/vm_dim_redim_test.go
@@ -143,6 +143,46 @@ func TestVMArrayElementSetGet(t *testing.T) {
 	}
 }
 
+// TestVMReDimPreserveJaggedArray verifies ReDim Preserve can grow a 1-D array
+// whose first element is itself an array (a jagged array), matching IIS/VBScript
+// behavior. Regression test for issue #32: AxonASP wrongly raised 800A0005
+// (Invalid procedure call or argument) because the outer 1-D array was mistaken
+// for a multi-dimensional array.
+func TestVMReDimPreserveJaggedArray(t *testing.T) {
+	source := `<%
+Dim outer()
+Dim inner(2)
+inner(0) = "a"
+inner(1) = "b"
+inner(2) = "c"
+ReDim outer(0)
+outer(0) = inner
+ReDim Preserve outer(1)
+outer(1) = "1"
+Response.Write outer(0)(0) & "," & outer(0)(1) & "," & outer(0)(2) & "<br>"
+Response.Write outer(1)
+%>`
+	compiler := NewASPCompiler(source)
+	if err := compiler.Compile(); err != nil {
+		t.Fatalf("compile failed: %v", err)
+	}
+
+	vm := NewVM(compiler.Bytecode(), compiler.Constants(), compiler.GlobalsCount())
+	host := NewMockHost()
+	var output bytes.Buffer
+	host.SetOutput(&output)
+	vm.SetHost(host)
+
+	if err := vm.Run(); err != nil {
+		t.Fatalf("vm run failed: %v", err)
+	}
+	host.Response().Flush()
+
+	if output.String() != "a,b,c<br>1" {
+		t.Fatalf("unexpected jagged ReDim Preserve output: got %q want %q", output.String(), "a,b,c<br>1")
+	}
+}
+
 // TestVMReDimPreserveMultiDimFirstDimensionChangeRejected verifies VBScript error 5 when Preserve changes non-last dimensions.
 func TestVMReDimPreserveMultiDimFirstDimensionChangeRejected(t *testing.T) {
 	source := `<%


### PR DESCRIPTION
## Summary

`ReDim Preserve` now correctly grows a 1-D array whose elements hold other arrays (a jagged array), instead of wrongly failing with runtime error `800A0005` (Invalid procedure call or argument).

## Root cause

`axonvm/builtins.go`, function `vbsAxonRedimPreserveArrayVB6` (the helper the compiler emits for every `ReDim Preserve` — see `compiler_stmt_parser.go` `__AXON_REDIM_PRESERVE_ARRAY_VB6`).

The reporter's lead was correct. The runtime has no dimension-count field on `VBArray` (`array_bridge.go`: a `VBArray` is just `{Lower, Values}`), so multi-dimensional arrays are represented structurally as nested arrays. To recover an array's rank, `vbArrayUpperBounds` (builtins.go:1005) walks down `current.Values[0]` and keeps descending as long as element `[0]` is itself an array:

```go
next, ok := toVBArray(current.Values[0]) // builtins.go:1017
if !ok { break }
current = next
```

For the reporter's script, `outer` is a 1-D array whose element `outer(0)` holds `inner` (itself an array). `vbArrayUpperBounds(outer)` therefore returns `[0, 2]` — it mistakes the jagged 1-D array for a 2-D array. `vbsAxonRedimPreserveArrayVB6` then looped over that structurally-derived rank and applied the VBScript rule "a non-last dimension may not change under `ReDim Preserve`" to dimension 0. Growing `outer` from upper bound 0 to 1 looked like an illegal change to a non-last dimension, so the function returned `InvalidProcedureCallOrArgument` (`800A0005`) on the `ReDim Preserve outer(1)` line.

The flaw is deriving rank by probing element `[0]`: a genuine 2-D array and a 1-D jagged array are structurally identical, so that probe cannot tell them apart.

## Change

Determine the array's rank from the number of subscripts the caller actually supplied, not by descending into element `[0]`. VBScript requires `ReDim Preserve` to specify the same number of dimensions as the array's declaration, so `numDims := len(bounds) / 2` is the authoritative rank for the operation:

```go
numDims := len(bounds) / 2
current := source
for i := 0; i < numDims; i++ {
    ...
    if i < numDims-1 { /* non-last dimension must match exactly */ }
    else            { /* last dimension: lower bound must match */ }
}
```

For legitimate rectangular arrays this is identical to the old behavior (structural depth equals declared rank). It differs only for a jagged 1-D array, which is exactly the mis-classified case. One helper call to `vbArrayUpperBounds` inside this function is dropped; the helper itself is unchanged and still used elsewhere.

## Validation

Added `TestVMReDimPreserveJaggedArray` (in `axonvm/vm_dim_redim_test.go`), the issue's minimal reproducer, asserting the IIS output `a,b,c<br>1`.

RED (before the fix):

```
=== RUN   TestVMReDimPreserveJaggedArray
    vm_dim_redim_test.go:177: vm run failed: VBScript runtime error '800A0005'
        Invalid procedure call or argument ... Line: 9   (the `ReDim Preserve outer(1)` line)
--- FAIL: TestVMReDimPreserveJaggedArray
```

GREEN (after the fix):

```
--- PASS: TestVMReDimPreserveJaggedArray (0.00s)
```

Over-correction guard: the existing `TestVMReDimPreserveMultiDimFirstDimensionChangeRejected` — which builds a genuine 2-D array `arr(2,3)` and asserts that `ReDim Preserve arr(3,3)` still raises error 5 — continues to pass, so genuine multi-dimensional non-last-dimension changes are still rejected:

```
--- PASS: TestVMReDimPreserveMultiDimFirstDimensionChangeRejected (0.00s)
```

Full package suite (`go test ./axonvm/`): the set of failing tests is byte-for-byte identical with and without this change (a handful of pre-existing, environment-dependent filesystem/IO tests — FSO, file-uploader, ADODB stream, node fs, include-path resolution — fail the same way on a clean checkout). This change introduces zero new failures. `go vet ./axonvm/` is clean.

## Note for maintainers (scope + a related tradeoff)

Because `VBArray` carries no stored dimension count, the runtime cannot distinguish a genuine 2-D array from a 1-D jagged array at the `ReDim Preserve` site — they are structurally identical. That ambiguity is the root of this bug, and it also has one edge-case consequence worth flagging:

- Supplying the **wrong number of subscripts** for a genuine multi-dimensional array — e.g. `ReDim Preserve arr(5)` (one subscript) on a real 2-D `arr(2,3)` — previously raised error 5, and with this change now succeeds silently (reinterpreting the array by the one supplied dimension). This is an invalid-input path (correct code always restates the full rank, which the guard test still covers), but it is a behavior change on that path.

Both this edge and the reporter's separate observation that `UBound(jaggedArray, 2)` reports a spurious second dimension stem from the same missing-rank limitation. The clean long-term fix is to store the declared dimension count on `VBArray`; that is a broader change than issue #32 warrants, so this PR keeps to the minimal, targeted fix and leaves the structural refactor for a separate discussion. Happy to follow up on it if you'd like.

Fixes #32