### PR TITLE
fix: don't replace ? placeholders for mssql

### DIFF
--- a/axonvm/lib_g3db.go
+++ b/axonvm/lib_g3db.go
@@ -1343,18 +1343,13 @@ func g3dbRewritePlaceholders(sqlText, driver string) string {
 		return g3dbReplaceQuestionMarks(sqlText, func(n int) string {
 			return fmt.Sprintf("$%d", n)
 		})
-	case "mssql":
-		// Replace ? with @p1, @p2, ... (SQL Server named positional notation).
-		return g3dbReplaceQuestionMarks(sqlText, func(n int) string {
-			return fmt.Sprintf("@p%d", n)
-		})
 	case "oracle":
 		// Replace ? with :p1, :p2, ... (go-ora/v2 positional notation).
 		return g3dbReplaceQuestionMarks(sqlText, func(n int) string {
 			return fmt.Sprintf(":p%d", n)
 		})
 	default:
-		// mysql, sqlite — ? is the native placeholder; return unchanged.
+		// mysql, sqlite, mssql - drivers accept ? placeholders without rewriting.
 		return sqlText
 	}
 }


### PR DESCRIPTION
mssql's driver also requires ? as placeholders.

How to reproduce the original error:
Create docker image:
```bash
docker run -e "ACCEPT_EULA=Y" \
           -e "MSSQL_SA_PASSWORD=YourStrong!Passw0rd" \
           -p 1433:1433 \
           --name sqlserver \
           -d mcr.microsoft.com/mssql/server:2022-latest

docker exec sqlserver /opt/mssql-tools18/bin/sqlcmd -S localhost -U sa -P 'YourStrong!Passw0rd' -C -Q "CREATE DATABASE test"
```
In `config/axonasp.toml` change `mssql_pass` to `YourStrong!Passw0rd`
Put the following script under `www/mssql.asp`
```asp
<%
Set db = Server.CreateObject("G3DB")
db.OpenFromEnv("mssql")

Db.Exec "CREATE TABLE test (success varchar(10))"
Db.Exec "DELETE FROM test"
for i = 0 to 10
	DB.Exec "INSERT INTO test VALUES(?)", i
next

Set rs = Db.Query("SELECT * FROM test")

Do While not rs.eof
	response.write rs("success")
	rs.movenext
Loop

db.Close
%>

```

With this PR `curl localhost:8801/mssql.asp` will output `Test: 012345678910`
Without it the output will only be `Test: `