### PR TITLE
fix: watch directories instead of individual script files

### DIFF
--- a/axonvm/script_cache.go
+++ b/axonvm/script_cache.go
@@ -725,22 +725,7 @@ func (c *ScriptCache) StartInvalidator(rootDirs []string) error {
 				if !ok {
 					return
 				}
-				if event.Op&(fsnotify.Write|fsnotify.Create|fsnotify.Remove) == 0 {
-					continue
-				}
-				if !c.shouldWatchScriptPath(event.Name) {
-					continue
-				}
-				if event.Op&fsnotify.Create != 0 {
-					_ = c.addWatchPathTracked(watcher, event.Name)
-				}
-				if event.Op&fsnotify.Remove != 0 {
-					c.removeWatchPathTracked(watcher, event.Name, false)
-				}
-				if !c.shouldProcessWatchEvent(event.Name) {
-					continue
-				}
-				c.Invalidate(event.Name)
+				c.handleWatchEvent(watcher, event)
 			case <-pruneTicker.C:
 				c.pruneStaleWatches(watcher)
 			case err, ok := <-watcher.Errors:
@@ -757,6 +742,31 @@ func (c *ScriptCache) StartInvalidator(rootDirs []string) error {
 	}()
 
 	return nil
+}
+
+func (c *ScriptCache) handleWatchEvent(watcher *fsnotify.Watcher, event fsnotify.Event) {
+	if event.Op&(fsnotify.Write|fsnotify.Create|fsnotify.Remove|fsnotify.Rename) == 0 {
+		return
+	}
+
+	if event.Op&fsnotify.Create != 0 {
+		if info, err := os.Stat(event.Name); err == nil && info.IsDir() {
+			_ = c.addWatchRecursiveTracked(watcher, event.Name)
+			return
+		}
+	}
+
+	if event.Op&(fsnotify.Remove|fsnotify.Rename) != 0 {
+		c.removeWatchPathTracked(watcher, event.Name, true)
+	}
+
+	if !c.shouldWatchScriptPath(event.Name) {
+		return
+	}
+	if !c.shouldProcessWatchEvent(event.Name) {
+		return
+	}
+	c.Invalidate(event.Name)
 }
 
 // StopInvalidator stops the active file watcher and goroutine.
@@ -1321,23 +1331,17 @@ func (c *ScriptCache) addWatchRecursiveTracked(watcher *fsnotify.Watcher, rootDi
 		return err
 	}
 	if !info.IsDir() {
-		if c.shouldWatchScriptPath(rootDir) {
-			return c.addWatchPathTracked(watcher, rootDir)
-		}
-		return nil
+		return c.addWatchPathTracked(watcher, filepath.Dir(rootDir))
 	}
 	return filepath.WalkDir(rootDir, func(path string, dirEntry os.DirEntry, walkErr error) error {
 		if walkErr != nil {
 			return nil
 		}
-		if dirEntry.IsDir() {
-			if shouldSkipScriptWatchDir(path, dirEntry.Name()) {
-				return filepath.SkipDir
-			}
+		if !dirEntry.IsDir() {
 			return nil
 		}
-		if !c.shouldWatchScriptPath(path) {
-			return nil
+		if shouldSkipScriptWatchDir(path, dirEntry.Name()) {
+			return filepath.SkipDir
 		}
 		return c.addWatchPathTracked(watcher, path)
 	})

--- a/axonvm/script_cache_test.go
+++ b/axonvm/script_cache_test.go
@@ -281,8 +281,8 @@ func TestScriptCacheAddWatchRecursiveTrackedDeduplicatesDirectories(t *testing.T
 		t.Fatalf("add recursive watch first pass: %v", err)
 	}
 	countFirst := len(cache.watchedPaths)
-	if countFirst != 1 {
-		t.Fatalf("expected 1 watched script file after first pass, got %d", countFirst)
+	if countFirst != 3 {
+		t.Fatalf("expected 3 watched directories (root, a, a/b) after first pass, got %d", countFirst)
 	}
 
 	if err := cache.addWatchRecursiveTracked(watcher, root); err != nil {
@@ -297,10 +297,11 @@ func TestScriptCacheAddWatchRecursiveTrackedDeduplicatesDirectories(t *testing.T
 func TestScriptCachePruneStaleWatchesRemovesDeletedDirectories(t *testing.T) {
 	cache := NewScriptCache(BytecodeCacheMemoryOnly, t.TempDir(), 8)
 	root := t.TempDir()
-	if err := os.MkdirAll(root, 0o755); err != nil {
-		t.Fatalf("mkdir root directory: %v", err)
+	sub := filepath.Join(root, "sub")
+	if err := os.MkdirAll(sub, 0o755); err != nil {
+		t.Fatalf("mkdir sub directory: %v", err)
 	}
-	aspFile := filepath.Join(root, "watched.asp")
+	aspFile := filepath.Join(sub, "watched.asp")
 	if err := os.WriteFile(aspFile, []byte("<% Response.Write 1 %>"), 0o644); err != nil {
 		t.Fatalf("write asp file: %v", err)
 	}
@@ -315,24 +316,81 @@ func TestScriptCachePruneStaleWatchesRemovesDeletedDirectories(t *testing.T) {
 		t.Fatalf("add recursive watch: %v", err)
 	}
 
-	normalizedASP, err := cache.normalizeAbsolutePath(aspFile)
+	normalizedSub, err := cache.normalizeAbsolutePath(sub)
 	if err != nil {
-		t.Fatalf("normalize asp file: %v", err)
+		t.Fatalf("normalize sub directory: %v", err)
 	}
-	normalizedASP = normalizeScriptCacheKey(normalizedASP)
-	if _, exists := cache.watchedPaths[normalizedASP]; !exists {
-		t.Fatalf("expected asp file to be tracked before deletion")
+	normalizedSub = normalizeScriptCacheKey(normalizedSub)
+	if _, exists := cache.watchedPaths[normalizedSub]; !exists {
+		t.Fatalf("expected sub directory to be tracked before deletion")
 	}
 
-	if err := os.Remove(aspFile); err != nil {
-		t.Fatalf("remove asp file: %v", err)
+	if err := os.RemoveAll(sub); err != nil {
+		t.Fatalf("remove sub directory: %v", err)
 	}
 
 	cache.pruneStaleWatches(watcher)
 
-	if _, exists := cache.watchedPaths[normalizedASP]; exists {
-		t.Fatalf("expected deleted script watch to be pruned")
+	if _, exists := cache.watchedPaths[normalizedSub]; exists {
+		t.Fatalf("expected deleted directory watch to be pruned")
 	}
+}
+
+// TestScriptCacheInvalidatesAfterAtomicRenameSave guards against a regression
+// where watching individual files instead of their directory let an atomic
+// save (write temp, rename over target) permanently kill the watch.
+func TestScriptCacheInvalidatesAfterAtomicRenameSave(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("rename-over-file watch semantics are POSIX-specific")
+	}
+
+	cache := NewScriptCache(BytecodeCacheMemoryOnly, t.TempDir(), 8)
+	root := t.TempDir()
+	aspFile := filepath.Join(root, "watched.asp")
+	if err := os.WriteFile(aspFile, []byte("<% Response.Write 1 %>"), 0o644); err != nil {
+		t.Fatalf("write asp file: %v", err)
+	}
+
+	if err := cache.StartInvalidator([]string{root}); err != nil {
+		t.Fatalf("start invalidator: %v", err)
+	}
+	defer cache.StopInvalidator()
+
+	normalized, err := cache.normalizeAbsolutePath(aspFile)
+	if err != nil {
+		t.Fatalf("normalize asp file: %v", err)
+	}
+
+	waitForInvalidation := func(label string) {
+		t.Helper()
+		deadline := time.Now().Add(2 * time.Second)
+		for time.Now().Before(deadline) {
+			if _, found := cache.Get(normalized); !found {
+				return
+			}
+			time.Sleep(20 * time.Millisecond)
+		}
+		t.Fatalf("expected cache invalidation %s", label)
+	}
+
+	cache.Put(normalized, CachedProgram{Bytecode: []byte{1}}, nil)
+	tempFile := aspFile + ".tmp"
+	if err := os.WriteFile(tempFile, []byte("<% Response.Write 2 %>"), 0o644); err != nil {
+		t.Fatalf("write temp file: %v", err)
+	}
+	if err := os.Rename(tempFile, aspFile); err != nil {
+		t.Fatalf("rename temp file over target: %v", err)
+	}
+	waitForInvalidation("after atomic rename save")
+
+	// An in-place edit after the rename must still invalidate, proving the
+	// directory watch survived the rename.
+	cache.Put(normalized, CachedProgram{Bytecode: []byte{1}}, nil)
+	time.Sleep(cache.watchDebounceWindow + 50*time.Millisecond)
+	if err := os.WriteFile(aspFile, []byte("<% Response.Write 3 %>"), 0o644); err != nil {
+		t.Fatalf("write asp file again: %v", err)
+	}
+	waitForInvalidation("after in-place edit following an atomic rename save")
 }
 
 func TestScriptCacheLoadOrCompileFallsBackToMemoryWhenDiskPersistFails(t *testing.T) {


### PR DESCRIPTION
This fixes an issue with editors like vim on Linux that do 'atomic saves' i. e. create a new file `*.tmp` and rename it on save.

Without this PR, after saving, files would stop being watched, and requesting the script would always execute the cached (old) version.

How to reproduce:
```bash
build/linux-amd64/axonasp-http
curl localhost:8801
vim www/default.asp
# edit and save file
curl localhost:8801
# --> changes are not reflected
```

It also has the nice added benefit of significantly reducing watch-descriptor counts on large Classic ASP projects.