### PR TITLE
Add AxonHTA desktop runtime, update the Caddy module and opt-in APIs …

### DIFF
--- a/.github/workflows/build-packages.yml
+++ b/.github/workflows/build-packages.yml
@@ -117,10 +117,6 @@ jobs:
           build_one "axonasp-admin$EXT"     admin
           build_one "axonasp-service$EXT"   service
           build_one "axonasp-testsuite$EXT" testsuite
-          # axonhta source directory conflicts with the output name when no .exe
-          # suffix is used.  Build to a temporary name then rename.
-          go build -trimpath -ldflags "${HTA_LDFLAGS}" -o "axonhta${EXT}.tmp" ./axonhta
-          mv "axonhta${EXT}.tmp" "axonhta${EXT}"
           if [ "${GOOS}" != "windows" ]; then build_one "axonasp-fpm" fpm; fi
 
       - name: Install xcaddy


### PR DESCRIPTION
…… (#64)

…with demo apps (#63)

## **Summary of Changes**

### **1. AxonHTA Desktop Runtime (New Feature)**

* **Core Engine:** Introduced **AxonHTA**, a modern reimagining of Microsoft's HTA model that embeds the AxonASP engine into a standalone executable using an embedded HTTP server and system browser.
* **Architecture & Features:**
* Added `.hta` file support with `<hta:application>` tag parsing.
* Embedded HTTP server on `127.0.0.1` with auto-picked ports and virtual path alias support.
* Persistent browser profiles (`LOCALAPPDATA` on Windows, `XDG` on Linux) and logging to file (`data/axonhta.log`).
* Heartbeat-based process lifecycle management and 3-layer panic recovery.
* Added `--dev` flag (auto-opens DevTools, skips context menu suppression) and graceful shutdown (`http.Server.Shutdown`).


* **Demo Applications:**
* Added `HTAtest/` with two ready-to-run demo apps: `axonhta-todo-app` (VBScript + HTML CRUD) and `axonhta-music-player` (HTMX + Alpine.js offline desktop app).


* **Documentation & Assets:** Added AxonHTA documentation, logo (`LogoHTA.svg`), sample application guides, and build-time versioning.

### **2. Caddy Server Integration & Packaging**

* **Configuration:** Added `nfpm-caddy.yaml` for packaging AxonASP alongside Caddy Server.
* **Testing:** Added `run-www-tests-cli.ps1` PowerShell script to automate testing ASP files using the AxonASP CLI.
* **Documentation:** Created `caddy-module.md` detailing installation, runtime features, and Caddyfile deployment examples.

### **3. Engine & Core Extensions (AxonVM / Parser)**

* **Opt-in APIs:** Added `SetFSOCacheDisabled(bool)` and `SetUnrestrictedFS(bool)` to support unrestricted file access and real-time FSO operations for desktop environments.
* **JScript Support:** Improved tolerance for try-catch and if-else statements using standard JScript semicolon handling.

### **4. Build System & Tooling Updates**

* **Build Targets:** Updated `build.ps1` and `build.sh` to include `axonhta` (with `-H windowsgui` on Windows) in build and clean targets.
* **Dependencies & Modules:** Updated Go modules and updated `go-isatty` to `v0.0.24`.
* **Tests:** Added 22 unit tests covering `app_runtime`, `hta_tag`, and `path_alias`.
* **Fixes & Cleanup:** Fixed upstream `axonvm/vm.go` compilation error (`instance.ClassName`), text typos, applied `go fmt`, and updated `.gitignore` (`.qoder`, `HTAtest` binaries).

---------

---------