### PR TITLE
Update upload-artifact action and enhance response handling

### DIFF
--- a/.github/workflows/build-packages.yml
+++ b/.github/workflows/build-packages.yml
@@ -241,6 +241,8 @@ jobs:
           for packager in deb rpm apk; do
             nfpm package --config nfpm-caddy.yaml --packager "${packager}" --target .
           done
+          # Move packages to workspace root so upload-artifact globs find them
+          mv ./*.deb ./*.rpm ./*.apk ../
           popd
 
       # ──────────────────────────────────────────────────────────────
@@ -296,7 +298,7 @@ jobs:
           tar -cJf "axonasp-freebsd-${VERSION}-${ARCH}.tar.xz" "${STAGE}/"
 
       - name: Upload artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: axonasp-${{ matrix.goos }}-${{ matrix.goarch }}
           path: |
@@ -346,7 +348,7 @@ jobs:
           zip -r "axonasp-wasm-${VERSION}.zip" "${STAGE}/"
 
       - name: Upload artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: axonasp-wasm
           path: "*.zip"
@@ -393,7 +395,7 @@ jobs:
         shell: pwsh
 
       - name: Upload installer artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: axonasp-installer-amd64
           path: installer-src\Output\*.exe

--- a/axonvm/asp/response.go
+++ b/axonvm/asp/response.go
@@ -304,6 +304,7 @@ func (r *Response) Clear() {
 		return
 	}
 	r.buffer.Reset()
+	r.flushed = false
 }
 
 // Flush sends buffered output to the client.
@@ -665,14 +666,15 @@ func (r *Response) IsEnded() bool {
 	return r.ended
 }
 
-// ResetEnded clears the ended flag so the response can continue accepting output.
-// This is used after Session_OnStart execution, where Response.End/Redirect may
-// have been called inside the suppressed-output scope and would otherwise
-// silently discard all subsequent page output.
+// ResetEnded clears the ended and flushed flags so the response can continue
+// accepting output. This is used after Session_OnStart execution, where
+// Response.End/Redirect may have been called inside the suppressed-output scope
+// and would otherwise silently discard all subsequent page output.
 func (r *Response) ResetEnded() {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 	r.ended = false
+	r.flushed = false
 }
 
 // flushInternal writes headers, cookies, and buffered content to the HTTP output.

--- a/axonvm/cookie_response_jscript_test.go
+++ b/axonvm/cookie_response_jscript_test.go
@@ -1,0 +1,85 @@
+package axonvm
+
+import (
+	"bytes"
+	"testing"
+)
+
+// TestJScriptResponseCookieSet verifies that Response.Cookies("name") = value
+// works correctly from JScript — cookie is set in response and flushed to output.
+func TestJScriptResponseCookieSet(t *testing.T) {
+	source := `<script runat="server" language="JScript">
+Response.Cookies("g3pix_lang") = "pt";
+Response.Cookies("g3pix_lang").Expires = new Date(Date.now() + 365 * 24 * 60 * 60 * 1000);
+Response.Cookies("g3pix_lang").Path = "/";
+Response.Write("ok");
+</script>`
+
+	compiler := NewASPCompiler(source)
+	if err := compiler.Compile(); err != nil {
+		t.Fatalf("compile failed: %v", err)
+	}
+
+	vm := NewVM(compiler.Bytecode(), compiler.Constants(), compiler.GlobalsCount())
+	host := NewMockHost()
+	var output bytes.Buffer
+	host.SetOutput(&output)
+	host.Response().SetBuffer(false)
+	vm.SetHost(host)
+
+	if err := vm.Run(); err != nil {
+		t.Fatalf("vm run failed: %v", err)
+	}
+	host.Response().Flush()
+
+	if output.String() != "ok" {
+		t.Errorf("expected output 'ok', got %q", output.String())
+	}
+
+	// Verify cookie is in response
+	cookieVal := host.Response().GetCookieValue("g3pix_lang")
+	if cookieVal != "pt" {
+		t.Errorf("expected cookie 'g3pix_lang' = 'pt', got %q", cookieVal)
+	}
+	t.Logf("Cookie value: %q", cookieVal)
+	t.Logf("Output: %q", output.String())
+}
+
+// TestJScriptResponseCookieSetAspMode reproduces the exact default.asp
+// cookie setting flow using <%@Language="JavaScript"%> directive (ASP mode).
+func TestJScriptResponseCookieSetAspMode(t *testing.T) {
+	source := `<%@Language="JavaScript"%>
+<%
+var queryLang = "pt";
+Response.Cookies("g3pix_lang") = queryLang;
+Response.Cookies("g3pix_lang").Expires = new Date(Date.now() + 365 * 24 * 60 * 60 * 1000);
+Response.Cookies("g3pix_lang").Path = "/";
+Response.Write("ok");
+%>`
+
+	compiler := NewASPCompiler(source)
+	if err := compiler.Compile(); err != nil {
+		t.Fatalf("compile failed: %v", err)
+	}
+
+	vm := NewVM(compiler.Bytecode(), compiler.Constants(), compiler.GlobalsCount())
+	host := NewMockHost()
+	var output bytes.Buffer
+	host.SetOutput(&output)
+	host.Response().SetBuffer(false)
+	vm.SetHost(host)
+
+	if err := vm.Run(); err != nil {
+		t.Fatalf("vm run failed: %v", err)
+	}
+	host.Response().Flush()
+
+	cookieVal := host.Response().GetCookieValue("g3pix_lang")
+	if cookieVal != "pt" {
+		t.Errorf("expected cookie 'g3pix_lang' = 'pt', got %q", cookieVal)
+	}
+	if output.String() != "ok" {
+		t.Errorf("expected output 'ok', got %q", output.String())
+	}
+	t.Logf("Cookie value: %q, Output: %q", cookieVal, output.String())
+}

--- a/axonvm/vm.go
+++ b/axonvm/vm.go
@@ -5777,7 +5777,7 @@ aspExecLoop:
 		vm.jsProcessMicrotasks()
 	}
 
-	if vm.host != nil && vm.host.Response() != nil {
+	if vm.host != nil && vm.host.Response() != nil && isRootRun {
 		vm.host.Response().Flush()
 	}
 


### PR DESCRIPTION
Upgrade the upload-artifact action to version 7 and move built Caddy packages to the workspace root for better artifact management. Improve response handling by resetting the flushed state and enhance cookie setting tests for JScript.