### PR TITLE
Enhance object reference counting and add regression tests

### DIFF
--- a/axonvm/vm.go
+++ b/axonvm/vm.go
@@ -9203,7 +9203,7 @@ func (vm *VM) setClassMemberValueByObjectID(objectID int64, memberName string, v
 // decrementObjectRefCount decrements the reference count of a VTObject and executes
 // Class_Terminate synchronously if refCount reaches zero.
 func (vm *VM) decrementObjectRefCount(obj Value) {
-	if obj.Type != VTObject {
+	if vm == nil || obj.Type != VTObject || vm.runtimeClassItems == nil {
 		return
 	}
 	instance, exists := vm.runtimeClassItems[obj.Num]
@@ -9249,7 +9249,7 @@ func (vm *VM) decrementObjectRefCount(obj Value) {
 
 // incrementObjectRefCount increments the reference count when a VTObject is assigned to a new slot.
 func (vm *VM) incrementObjectRefCount(obj Value) {
-	if obj.Type != VTObject {
+	if vm == nil || obj.Type != VTObject || vm.runtimeClassItems == nil {
 		return
 	}
 	instance, exists := vm.runtimeClassItems[obj.Num]
@@ -9677,14 +9677,22 @@ func (vm *VM) beginUserSubCall(target Value, args []Value, discardReturn bool, b
 
 		if argIdx < len(args) {
 			// Normal argument provided.
-			vm.stack[vm.fp+paramIdx] = args[argIdx]
+			argVal := args[argIdx]
+			vm.stack[vm.fp+paramIdx] = argVal
+			if argVal.Type == VTObject {
+				vm.incrementObjectRefCount(argVal)
+			}
 			argIdx++
 		} else if (optionalMask>>uint(paramIdx))&1 == 1 {
 			// Optional parameter with no argument provided - use default value.
 			if hasDefaults && paramIdx < len(defaults) && defaults[paramIdx] >= 0 {
 				defaultIdx := defaults[paramIdx]
 				if defaultIdx >= 0 && defaultIdx < len(vm.constants) {
-					vm.stack[vm.fp+paramIdx] = vm.constants[defaultIdx]
+					val := vm.constants[defaultIdx]
+					vm.stack[vm.fp+paramIdx] = val
+					if val.Type == VTObject {
+						vm.incrementObjectRefCount(val)
+					}
 				} else {
 					vm.stack[vm.fp+paramIdx] = Value{Type: VTEmpty}
 				}

--- a/axonvm/vm_synchronous_terminate_test.go
+++ b/axonvm/vm_synchronous_terminate_test.go
@@ -270,3 +270,239 @@ Set c = Nothing
 	}
 	vm2.Release()
 }
+
+// TestPassObjectArgumentRegressionBuilderPattern verifies that passing a class instance
+// as a function argument does not cause premature object destruction upon function return.
+func TestPassObjectArgumentRegressionBuilderPattern(t *testing.T) {
+	source := `<%
+Option Explicit
+
+Class Computer
+    Public CPU As String, RAM As String, Disk As String
+    Public Function ShowConfig
+        Response.Write("CPU=" & CPU & " RAM=" & RAM & " Disk=" & Disk)
+    End Function
+End Class
+
+Class IBuilder
+    Public Function BuildCPU(v As String)
+    End Function
+    Public Function GetResult As Computer
+    End Function
+End Class
+
+Class ComputerBuilder
+    Implements IBuilder
+    Private m_Computer As Computer
+
+    Private Sub Class_Initialize
+        Set m_Computer = New Computer
+    End Sub
+
+    Public Function IBuilder_BuildCPU(v As String)
+        m_Computer.CPU = v
+    End Function
+
+    Public Function IBuilder_GetResult As Computer
+        Set IBuilder_GetResult = m_Computer
+    End Function
+End Class
+
+Class Director
+    Public Function ConstructGamingPC(builder As IBuilder)
+        builder.BuildCPU("i9")
+    End Function
+End Class
+
+Dim myBuilder As IBuilder
+Dim myDirector As Director
+Dim pc As Computer
+
+Set myBuilder = New ComputerBuilder
+Set myDirector = New Director
+
+myDirector.ConstructGamingPC(myBuilder)
+
+Set pc = myBuilder.GetResult
+pc.ShowConfig
+%>`
+
+	compiler := NewASPCompiler(source)
+	if err := compiler.Compile(); err != nil {
+		t.Fatalf("compile failed: %v", err)
+	}
+
+	vm := NewVM(compiler.Bytecode(), compiler.Constants(), compiler.GlobalsCount())
+	host := NewMockHost()
+	var output bytes.Buffer
+	host.SetOutput(&output)
+	vm.SetHost(host)
+
+	if err := vm.Run(); err != nil {
+		t.Fatalf("vm run failed: %v", err)
+	}
+	host.Response().Flush()
+
+	expected := "CPU=i9 RAM= Disk="
+	if output.String() != expected {
+		t.Fatalf("expected output %q, got %q", expected, output.String())
+	}
+}
+
+// TestPassSameObjectMultipleArguments verifies that passing the same object as multiple arguments
+// to a single function increments and decrements refCount correctly without early termination.
+func TestPassSameObjectMultipleArguments(t *testing.T) {
+	source := `<%
+Dim trace
+trace = ""
+
+Class TrackedObj
+	Public Name
+	Private Sub Class_Initialize()
+		Name = "Test"
+	End Sub
+	Private Sub Class_Terminate()
+		trace = trace & "[Terminated]"
+	End Sub
+End Class
+
+Sub CheckMatch(obj1, obj2)
+	trace = trace & "[InsideCheck:" & obj1.Name & "=" & obj2.Name & "]"
+End Sub
+
+Dim myObj
+Set myObj = New TrackedObj
+trace = trace & "[Created]"
+CheckMatch myObj, myObj
+trace = trace & "[AfterCall:" & myObj.Name & "]"
+Set myObj = Nothing
+trace = trace & "[AfterNothing]"
+
+Response.Write trace
+%>`
+
+	compiler := NewASPCompiler(source)
+	if err := compiler.Compile(); err != nil {
+		t.Fatalf("compile failed: %v", err)
+	}
+
+	vm := NewVM(compiler.Bytecode(), compiler.Constants(), compiler.GlobalsCount())
+	host := NewMockHost()
+	var output bytes.Buffer
+	host.SetOutput(&output)
+	vm.SetHost(host)
+
+	if err := vm.Run(); err != nil {
+		t.Fatalf("vm run failed: %v", err)
+	}
+	host.Response().Flush()
+
+	expected := "[Created][InsideCheck:Test=Test][AfterCall:Test][Terminated][AfterNothing]"
+	if output.String() != expected {
+		t.Fatalf("expected output %q, got %q", expected, output.String())
+	}
+}
+
+// TestPassNothingAsArgument verifies that passing Nothing as a function parameter
+// does not cause a panic during incrementObjectRefCount.
+func TestPassNothingAsArgument(t *testing.T) {
+	source := `<%
+Dim trace
+trace = ""
+
+Sub ProcessObj(obj)
+	If obj Is Nothing Then
+		trace = trace & "[ObjIsNothing]"
+	Else
+		trace = trace & "[ObjValid]"
+	End If
+End Sub
+
+ProcessObj Nothing
+Response.Write trace
+%>`
+
+	compiler := NewASPCompiler(source)
+	if err := compiler.Compile(); err != nil {
+		t.Fatalf("compile failed: %v", err)
+	}
+
+	vm := NewVM(compiler.Bytecode(), compiler.Constants(), compiler.GlobalsCount())
+	host := NewMockHost()
+	var output bytes.Buffer
+	host.SetOutput(&output)
+	vm.SetHost(host)
+
+	if err := vm.Run(); err != nil {
+		t.Fatalf("vm run failed: %v", err)
+	}
+	host.Response().Flush()
+
+	expected := "[ObjIsNothing]"
+	if output.String() != expected {
+		t.Fatalf("expected output %q, got %q", expected, output.String())
+	}
+}
+
+// TestPassObjectNestedFunctionCalls verifies that passing an object through nested function calls
+// allows the object to survive until the outermost scope releases it.
+func TestPassObjectNestedFunctionCalls(t *testing.T) {
+	source := `<%
+Dim trace
+trace = ""
+
+Class Item
+	Public Val
+	Private Sub Class_Terminate()
+		trace = trace & "[ItemTerminated]"
+	End Sub
+End Class
+
+Function FuncB(o)
+	trace = trace & "[FuncB:" & o.Val & "]"
+	o.Val = o.Val + 10
+	Set FuncB = o
+End Function
+
+Function FuncA(o)
+	trace = trace & "[FuncA:" & o.Val & "]"
+	o.Val = o.Val + 100
+	Set FuncA = o
+End Function
+
+Dim myObj, res
+Set myObj = New Item
+myObj.Val = 1
+trace = trace & "[Created]"
+
+Set res = FuncA(FuncB(myObj))
+trace = trace & "[FinalVal:" & res.Val & "]"
+Set res = Nothing
+trace = trace & "[AfterResNothing]"
+Set myObj = Nothing
+trace = trace & "[AfterMyObjNothing]"
+
+Response.Write trace
+%>`
+
+	compiler := NewASPCompiler(source)
+	if err := compiler.Compile(); err != nil {
+		t.Fatalf("compile failed: %v", err)
+	}
+
+	vm := NewVM(compiler.Bytecode(), compiler.Constants(), compiler.GlobalsCount())
+	host := NewMockHost()
+	var output bytes.Buffer
+	host.SetOutput(&output)
+	vm.SetHost(host)
+
+	if err := vm.Run(); err != nil {
+		t.Fatalf("vm run failed: %v", err)
+	}
+	host.Response().Flush()
+
+	expected := "[Created][FuncB:1][FuncA:11][FinalVal:111][AfterResNothing][ItemTerminated][AfterMyObjNothing]"
+	if output.String() != expected {
+		t.Fatalf("expected output %q, got %q", expected, output.String())
+	}
+}


### PR DESCRIPTION
Improve object reference counting in VM methods to ensure proper handling of object arguments. Add regression tests to verify that passing objects as function arguments does not lead to premature destruction or incorrect reference counting. Fix #103