### PR TITLE
Fix parenless method call on array element callee and nil map panic issues

### DIFF
--- a/axonvm/compiler_stmt_parser.go
+++ b/axonvm/compiler_stmt_parser.go
@@ -922,6 +922,39 @@ func (c *Compiler) parseStatementCallChain() bool {
 				return true
 			}
 
+			// Member sub call without parentheses: obj(i).Method arg1, arg2.
+			// When the token after the member name starts an argument expression
+			// (not '(', '=', '.' and not end-of-statement), parse the no-paren
+			// argument list. Mirrors the inline path in parseStatement that
+			// already handles "obj.Method arg1, arg2" for simple-variable callees.
+			if nd, ok := c.next.(*vbscript.PunctuationToken); !ok || nd.Type != vbscript.PunctDot {
+				if !c.isStatementEnd() {
+					argCount := 0
+					for {
+						if comma, ok := c.next.(*vbscript.PunctuationToken); ok && comma.Type == vbscript.PunctComma {
+							emptyIdx := c.addConstant(NewEmpty())
+							c.emit(OpConstant, emptyIdx)
+						} else if c.isStatementEnd() {
+							emptyIdx := c.addConstant(NewEmpty())
+							c.emit(OpConstant, emptyIdx)
+						} else {
+							mscArgStartPos := len(c.bytecode)
+							c.parseExpression(PrecNone)
+							c.patchArgRefInBytecode(mscArgStartPos)
+						}
+						argCount++
+						if p, ok := c.next.(*vbscript.PunctuationToken); ok && p.Type == vbscript.PunctComma {
+							c.move()
+						} else {
+							break
+						}
+					}
+					c.emit(OpCallMember, midx, argCount)
+					c.emit(OpPop)
+					return true
+				}
+			}
+
 			c.emit(OpConstant, midx)
 			c.emit(OpMemberGet)
 			continue

--- a/axonvm/compiler_stmt_parser.go
+++ b/axonvm/compiler_stmt_parser.go
@@ -922,9 +922,39 @@ func (c *Compiler) parseStatementCallChain() bool {
 				return true
 			}
 
-			c.emit(OpConstant, midx)
-			c.emit(OpMemberGet)
-			continue
+			if dot2, ok := c.next.(*vbscript.PunctuationToken); ok && dot2.Type == vbscript.PunctDot {
+				c.emit(OpConstant, midx)
+				c.emit(OpMemberGet)
+				continue
+			}
+
+			// No-parens member call (or 0-argument sub call at statement end) on call chain target:
+			// e.g. m_Obs(i).Update news  or  m_Arr(0).Receive msg, fromUser
+			argCount := 0
+			if !c.isStatementEnd() {
+				for {
+					if comma, ok := c.next.(*vbscript.PunctuationToken); ok && comma.Type == vbscript.PunctComma {
+						emptyIdx := c.addConstant(NewEmpty())
+						c.emit(OpConstant, emptyIdx)
+					} else if c.isStatementEnd() {
+						emptyIdx := c.addConstant(NewEmpty())
+						c.emit(OpConstant, emptyIdx)
+					} else {
+						mscArgStartPos := len(c.bytecode)
+						c.parseExpression(PrecNone)
+						c.patchArgRefInBytecode(mscArgStartPos)
+					}
+					argCount++
+					if p, ok := c.next.(*vbscript.PunctuationToken); ok && p.Type == vbscript.PunctComma {
+						c.move()
+					} else {
+						break
+					}
+				}
+			}
+			c.emit(OpCallMember, midx, argCount)
+			c.emit(OpPop)
+			return true
 		}
 
 		if lp, ok := c.next.(*vbscript.PunctuationToken); ok && lp.Type == vbscript.PunctLParen {
@@ -945,6 +975,29 @@ func (c *Compiler) parseStatementCallChain() bool {
 	}
 
 	if handled {
+		if !c.isStatementEnd() {
+			argCount := 0
+			for {
+				if comma, ok := c.next.(*vbscript.PunctuationToken); ok && comma.Type == vbscript.PunctComma {
+					emptyIdx := c.addConstant(NewEmpty())
+					c.emit(OpConstant, emptyIdx)
+				} else if c.isStatementEnd() {
+					emptyIdx := c.addConstant(NewEmpty())
+					c.emit(OpConstant, emptyIdx)
+				} else {
+					mscArgStartPos := len(c.bytecode)
+					c.parseExpression(PrecNone)
+					c.patchArgRefInBytecode(mscArgStartPos)
+				}
+				argCount++
+				if p, ok := c.next.(*vbscript.PunctuationToken); ok && p.Type == vbscript.PunctComma {
+					c.move()
+				} else {
+					break
+				}
+			}
+			c.emit(OpCall, argCount)
+		}
 		c.emit(OpPop)
 	}
 	return handled

--- a/axonvm/compiler_stmt_parser.go
+++ b/axonvm/compiler_stmt_parser.go
@@ -922,39 +922,6 @@ func (c *Compiler) parseStatementCallChain() bool {
 				return true
 			}
 
-			// Member sub call without parentheses: obj(i).Method arg1, arg2.
-			// When the token after the member name starts an argument expression
-			// (not '(', '=', '.' and not end-of-statement), parse the no-paren
-			// argument list. Mirrors the inline path in parseStatement that
-			// already handles "obj.Method arg1, arg2" for simple-variable callees.
-			if nd, ok := c.next.(*vbscript.PunctuationToken); !ok || nd.Type != vbscript.PunctDot {
-				if !c.isStatementEnd() {
-					argCount := 0
-					for {
-						if comma, ok := c.next.(*vbscript.PunctuationToken); ok && comma.Type == vbscript.PunctComma {
-							emptyIdx := c.addConstant(NewEmpty())
-							c.emit(OpConstant, emptyIdx)
-						} else if c.isStatementEnd() {
-							emptyIdx := c.addConstant(NewEmpty())
-							c.emit(OpConstant, emptyIdx)
-						} else {
-							mscArgStartPos := len(c.bytecode)
-							c.parseExpression(PrecNone)
-							c.patchArgRefInBytecode(mscArgStartPos)
-						}
-						argCount++
-						if p, ok := c.next.(*vbscript.PunctuationToken); ok && p.Type == vbscript.PunctComma {
-							c.move()
-						} else {
-							break
-						}
-					}
-					c.emit(OpCallMember, midx, argCount)
-					c.emit(OpPop)
-					return true
-				}
-			}
-
 			c.emit(OpConstant, midx)
 			c.emit(OpMemberGet)
 			continue

--- a/axonvm/interface_nil_map_panic_test.go
+++ b/axonvm/interface_nil_map_panic_test.go
@@ -1,0 +1,78 @@
+/*
+ * AxonASP Server
+ * Copyright (C) 2026 G3pix Ltda. All rights reserved.
+ *
+ * Developed by Lucas Guimarães - G3pix Ltda
+ * Contact: https://g3pix.com.br
+ * Project URL: https://g3pix.com.br/axonasp
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+package axonvm
+
+import (
+	"testing"
+)
+
+func TestInterfaceNilMapPanic(t *testing.T) {
+	code := `<%
+Option Explicit
+
+Class ICloneable
+    Public Function Clone As ICloneable
+    End Function
+End Class
+
+Class MyResume
+    Implements ICloneable
+    Public Name As String
+    Public Age As Integer
+    Public Skills
+
+    Public Function ICloneable_Clone As ICloneable
+        Dim copy As MyResume
+        Set copy = New MyResume
+        copy.Name = Me.Name
+        copy.Age = Me.Age
+        
+        Dim ub As Integer, i As Integer, arr
+        ub = UBound(Me.Skills)
+        ReDim arr(ub)
+        For i = 0 To ub
+            arr(i) = Me.Skills(i)
+        Next
+        copy.Skills = arr
+        Set ICloneable_Clone = copy
+    End Function
+End Class
+
+' Demo Execution
+Dim r1 As MyResume
+Dim r2 As ICloneable
+Dim r2Copy As MyResume
+Set r1 = New MyResume
+r1.Name = "张三"
+r1.Age = 25
+r1.Skills = Array("VBScript", "HTML")
+
+Set r2 = r1.Clone()         ' Interface method return → interface variable
+Set r2Copy = r2             ' Interface variable → concrete class variable
+r2Copy.Name = "李四"         ' ← CRASH: assignment to entry in nil map
+r2Copy.Skills(0) = "JavaScript"
+
+Response.Write(r1.Name & " " & r1.Skills(0))
+Response.Write(r2Copy.Name & " " & r2Copy.Skills(0))
+%>`
+
+	output, err := runVBScriptTest(code)
+	if err != nil {
+		t.Fatalf("Execution failed: %v", err)
+	}
+
+	expected := "张三 VBScript李四 JavaScript"
+	if output != expected {
+		t.Errorf("Expected output %q, got %q", expected, output)
+	}
+}

--- a/axonvm/parenless_array_call_test.go
+++ b/axonvm/parenless_array_call_test.go
@@ -1,0 +1,157 @@
+/*
+ * AxonASP Server
+ * Copyright (C) 2026 G3pix Ltda. All rights reserved.
+ *
+ * Developed by Lucas Guimarães - G3pix Ltda
+ * Contact: https://g3pix.com.br
+ * Project URL: https://g3pix.com.br/axonasp
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+package axonvm
+
+import (
+	"testing"
+)
+
+// TestParenlessMethodCallVariant1_ConcatenatedExpression verifies that parenless method calls
+// on array elements with concatenated expression arguments (e.g. m_Items(0).Show prefix & "-")
+// parse and execute without syntax or runtime errors.
+func TestParenlessMethodCallVariant1_ConcatenatedExpression(t *testing.T) {
+	source := `<%
+Class ItemClass
+    Public Sub Show(val)
+        Response.Write "SHOW:" & val
+    End Sub
+End Class
+
+Class Holder
+    Private m_Items()
+    Private Sub Class_Initialize(): ReDim m_Items(1): End Sub
+    Public Function Add(item): Set m_Items(0) = item: End Function
+    Public Function Run(prefix)
+        m_Items(0).Show prefix & "-"
+    End Function
+End Class
+
+Dim item, h
+Set item = New ItemClass
+Set h = New Holder
+h.Add item
+h.Run "HELLO"
+%>`
+	out := runASPSourceForTest(t, source)
+	if out != "SHOW:HELLO-" {
+		t.Fatalf("expected 'SHOW:HELLO-' got %q", out)
+	}
+}
+
+// TestParenlessMethodCallVariant2_MultipleArguments verifies that parenless method calls
+// on array elements with multiple simple arguments (e.g. m_Arr(0).Receive msg, fromUser)
+// correctly bind both arguments without evaluating to Empty.
+func TestParenlessMethodCallVariant2_MultipleArguments(t *testing.T) {
+	source := `<%
+Class Receiver
+    Public Sub Receive(msg, fromUser)
+        Response.Write "REC:" & msg & " FROM " & fromUser
+    End Sub
+End Class
+
+Class B
+    Private m_Arr()
+    Private Sub Class_Initialize(): ReDim m_Arr(1): End Sub
+    Public Function Store(obj): Set m_Arr(0) = obj: End Function
+    Public Function Relay(msg, fromUser)
+        m_Arr(0).Receive msg, fromUser
+    End Function
+End Class
+
+Dim r, b
+Set r = New Receiver
+Set b = New B
+b.Store r
+b.Relay "HELLO", "ALICE"
+%>`
+	out := runASPSourceForTest(t, source)
+	if out != "REC:HELLO FROM ALICE" {
+		t.Fatalf("expected 'REC:HELLO FROM ALICE' got %q", out)
+	}
+}
+
+// TestParenlessMethodCallVariant3_SingleArgument verifies that parenless method calls
+// on array elements with a single argument inside a loop (e.g. m_Obs(i).Update news)
+// pass the argument correctly without dropping it silently.
+func TestParenlessMethodCallVariant3_SingleArgument(t *testing.T) {
+	source := `<%
+Class Observer
+    Public Sub Update(news)
+        Response.Write "UPD:" & news & ";"
+    End Sub
+End Class
+
+Class Pub
+    Private m_Obs()
+    Private m_Count
+    Private Sub Class_Initialize(): m_Count = 0: ReDim m_Obs(10): End Sub
+    Public Function Add(o): Set m_Obs(m_Count) = o: m_Count = m_Count + 1: End Function
+    Public Function Notify(news)
+        Dim i
+        For i = 0 To m_Count - 1
+            m_Obs(i).Update news
+        Next
+    End Function
+End Class
+
+Dim obs1, obs2, pub
+Set obs1 = New Observer
+Set obs2 = New Observer
+Set pub = New Pub
+pub.Add obs1
+pub.Add obs2
+pub.Notify "BREAKING NEWS"
+%>`
+	out := runASPSourceForTest(t, source)
+	if out != "UPD:BREAKING NEWS;UPD:BREAKING NEWS;" {
+		t.Fatalf("expected 'UPD:BREAKING NEWS;UPD:BREAKING NEWS;' got %q", out)
+	}
+}
+
+// TestParenlessMethodCallChainedAccess verifies multi-level chained property and method calls
+// on array elements (e.g. m_Arr(0).SubObj.Update news).
+func TestParenlessMethodCallChainedAccess(t *testing.T) {
+	source := `<%
+Class SubClass
+    Public Sub Update(news)
+        Response.Write "SUB:" & news
+    End Sub
+End Class
+
+Class MainClass
+    Public SubObj
+    Private Sub Class_Initialize()
+        Set SubObj = New SubClass
+    End Sub
+End Class
+
+Class Container
+    Private m_Arr()
+    Private Sub Class_Initialize()
+        ReDim m_Arr(1)
+        Set m_Arr(0) = New MainClass
+    End Sub
+    Public Function Run(news)
+        m_Arr(0).SubObj.Update news
+    End Function
+End Class
+
+Dim c
+Set c = New Container
+c.Run "DATA"
+%>`
+	out := runASPSourceForTest(t, source)
+	if out != "SUB:DATA" {
+		t.Fatalf("expected 'SUB:DATA' got %q", out)
+	}
+}

--- a/axonvm/vm.go
+++ b/axonvm/vm.go
@@ -5780,7 +5780,8 @@ aspExecLoop:
 
 			// Decrement reference counts for all local variables going out of scope.
 			for _, val := range exitingLocals {
-				vm.decrementObjectRefCount(val)
+				isRetVal := !frame.discard && retVal.Type == VTObject && val.Type == VTObject && val.Num == retVal.Num
+				vm.decrementObjectRefCountEx(val, isRetVal)
 			}
 
 		case OpSwap:
@@ -9203,6 +9204,11 @@ func (vm *VM) setClassMemberValueByObjectID(objectID int64, memberName string, v
 // decrementObjectRefCount decrements the reference count of a VTObject and executes
 // Class_Terminate synchronously if refCount reaches zero.
 func (vm *VM) decrementObjectRefCount(obj Value) {
+	vm.decrementObjectRefCountEx(obj, false)
+}
+
+// decrementObjectRefCountEx decrements refCount and optionally protects active return values from premature termination.
+func (vm *VM) decrementObjectRefCountEx(obj Value, isReturnValue bool) {
 	if vm == nil || obj.Type != VTObject || vm.runtimeClassItems == nil {
 		return
 	}
@@ -9216,6 +9222,9 @@ func (vm *VM) decrementObjectRefCount(obj Value) {
 	instance.refCount--
 	if instance.refCount <= 0 {
 		instance.refCount = 0 // Ensure non-negative for safety.
+		if isReturnValue {
+			return // Do not terminate or nullify Members when this object is the active return value being passed to caller.
+		}
 		instance.terminated = true
 
 		if !vm.suppressTerminate {


### PR DESCRIPTION
Enhance the handling of parenless method calls on array elements to correctly parse and execute arguments, addressing three related bugs. The changes ensure that calls like `m_Items(0).Show prefix & "-"` no longer produce compile errors, runtime errors, or silently drop arguments. Additionally, improve reference counting to prevent nil map panics when assigning to fields of objects obtained via interface-to-concrete-class assignments. All related tests pass successfully, matching the behavior of the classic VBScript engine.

Fixes #105, #106, #107, #108.