### PR TITLE
Update module version to v2.3.18 and adjust Dockerfile for Caddy integration

### DIFF
--- a/caddy/go.mod
+++ b/caddy/go.mod
@@ -6,7 +6,7 @@ go 1.26.5
 replace github.com/google/cel-go => github.com/google/cel-go v0.20.1
 
 require (
-	g3pix.com.br/axonasp/v2 v2.3.17
+	g3pix.com.br/axonasp/v2 v2.3.18
 	github.com/caddyserver/caddy/v2 v2.11.4
 	github.com/spf13/viper v1.21.0
 	go.uber.org/zap v1.28.0

--- a/docker/Dockerfile.caddy
+++ b/docker/Dockerfile.caddy
@@ -51,8 +51,8 @@ RUN if [ -z "$VERSION" ]; then \
     cd caddy && \
     CGO_ENABLED=0 GOOS=${TARGETOS} GOARCH=${TARGETARCH} \
     xcaddy build \
-    --with g3pix.com.br/axonasp/caddy=. \
-    --replace "g3pix.com.br/axonasp=/build" \
+    --with g3pix.com.br/axonasp/v2/caddy=. \
+    --replace "g3pix.com.br/axonasp/v2=/build" \
     --replace "github.com/google/cel-go=github.com/google/cel-go@v0.20.1" && \
     ls -la caddy
 


### PR DESCRIPTION
Update the module version to v2.3.18 and modify Dockerfile paths to ensure proper integration with Caddy.