### PR TITLE
Update Dockerfiles to use Go 1.27

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,7 +21,7 @@
 #
 
 # ─── Stage 1: Builder ────────────────────────────────────────────────────────
-FROM golang:1.26-alpine AS builder
+FROM golang:1.27-alpine AS builder
 
 ARG TARGETOS=linux
 ARG TARGETARCH=amd64

--- a/docker/Dockerfile.caddy
+++ b/docker/Dockerfile.caddy
@@ -22,7 +22,7 @@
 #
 
 # ─── Stage 1: Builder ────────────────────────────────────────────────────────
-FROM golang:1.26-alpine AS builder
+FROM golang:1.27-alpine AS builder
 
 ARG TARGETOS=linux
 ARG TARGETARCH=amd64


### PR DESCRIPTION
Upgrade the base image in Dockerfiles to Go 1.27 for improved performance and features.